### PR TITLE
Add Fellow

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -79,6 +79,8 @@ Wenn du zu dieser Liste beitragen möchtest, schicke einen Pull Request! Vielen 
 - [Codex](https://openai.com/blog/openai-codex/): KI-System von OpenAI, das natürliche Sprache in Code übersetzt.
 
 - [Github Copilot](https://copilot.github.com/): KI-System von Github, das auf Codes aufbaut und natürliche Sprache in Code übersetzt. Kann in viele IDEs integriert werden (wie z.B. VS Code).
+- 
+- [Fellow](https://github.com/ManuelZierl/fellow) - Fellow ist ein Open-Source-Kommandozeilen-KI-Assistent. Im Gegensatz zu den meisten KI-Tools, die sich darauf beschränken, Code vorzuschlagen, geht Fellow einen Schritt weiter: Er führt Aufgaben in Ihrem Namen aus. Er begründet Schritt für Schritt, wählt Befehle aus einem Plugin-System aus und bearbeitet Dateien, generiert Inhalte oder schreibt Tests - autonom.
 
 ### Code-Überprüfung
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If you want to contribute to this list, send a PR! Thanks for your awesome contr
 - [Github Copilot](https://copilot.github.com/) - AI system by Github built on top of Codes that translates natural language to code. Can be integrated in many IDEs (such as VS Code)
 - [Safurai](https://www.safurai.com/) - Safurai is the AI Code Assistant that saves you time in changing, optimizing, and searching code.
 - [AIHelperBot](https://aihelperbot.com/) - Build SQL queries using AI
+- [Fellow](https://github.com/ManuelZierl/fellow) - Fellow is a open-source command-line AI assistant. Unlike most AI tools that stop at suggesting code, Fellow goes a step further: It executes tasks on your behalf. It reasons step-by-step, chooses commands from a plugin system, and edits files, generates content, or writes tests — autonomously.
 
 ### Code checking
 


### PR DESCRIPTION
[Fellow ](https://github.com/ManuelZierl/fellow) is a command-line AI assistant built by developers, for developers.

Unlike most AI tools that stop at suggesting code, Fellow goes a step further:
It executes tasks on your behalf. It reasons step-by-step, chooses commands from a plugin system, and edits files, generates content, or writes tests — autonomously.

Documentation can be found [here](https://manuelzierl.github.io/fellow/)